### PR TITLE
Add dark mode toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Jasmin SMS GUI
 
-A [Py4web](https://py4web.com/) GUI application for managing and monitoring all aspects of a a single instance of the popular open source [Jasmin SMS Gateway](https://github.com/jookies/jasmin) as an alternative to the standard jcli command line interface. 
+A [Py4web](https://py4web.com/) GUI application for managing and monitoring all aspects of a a single instance of the popular open source [Jasmin SMS Gateway](https://github.com/jookies/jasmin) as an alternative to the standard jcli command line interface.
+
+## Interface features
+
+* Responsive layout built with Bulma and Bootstrap
+* Toggleable dark/light theme (use the icon in the navigation bar)
 
 ## Getting Started
 

--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -1,0 +1,20 @@
+:root {
+  --bg-color: #ffffff;
+  --text-color: #333333;
+  --navbar-bg: #f5f5f5;
+}
+
+body.dark-mode {
+  --bg-color: #121212;
+  --text-color: #f5f5f5;
+  --navbar-bg: #1f1f1f;
+}
+
+body {
+  background-color: var(--bg-color);
+  color: var(--text-color);
+}
+
+.navbar.is-light {
+  background-color: var(--navbar-bg);
+}

--- a/static/js/theme.js
+++ b/static/js/theme.js
@@ -1,0 +1,17 @@
+(function(){
+  function applyTheme(dark){
+    if(dark){
+      document.body.classList.add('dark-mode');
+    } else {
+      document.body.classList.remove('dark-mode');
+    }
+    localStorage.setItem('darkMode', dark ? '1' : '0');
+  }
+  var stored = localStorage.getItem('darkMode');
+  var dark = stored === '1';
+  applyTheme(dark);
+  window.toggleDarkMode = function(){
+    dark = !dark;
+    applyTheme(dark);
+  };
+})();

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -12,6 +12,7 @@
     <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
     <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.14.0/css/all.min.css" integrity="sha512-1PKOgIY59xJ8Co8+NE6FZ+LOAZKjy+KY8iq0G4B3CyeY6wYHN3yt9PW0XpSriVlkMXe40PTKnXrLnZ9+fkDaog==" crossorigin="anonymous" />
+    <link rel="stylesheet" href="css/theme.css">
     <style>.py4web-validation-error{margin-top:-16px; font-size:0.8em;color:red}</style>
     [[block page_head]]<!-- individual pages can customize header here -->[[end]]
   </head>
@@ -30,7 +31,14 @@
       </div>
       <div id="left-navbar" class="navbar-menu">
         <div class="navbar-start">
-	      [[block page_menu_items]]<!-- individual pages can add menu items here -->[[end]]
+              [[block page_menu_items]]<!-- individual pages can add menu items here -->[[end]]
+        </div>
+        <div class="navbar-end">
+          <div class="navbar-item">
+            <button class="button is-small" onclick="toggleDarkMode()" title="Toggle dark mode">
+              <span class="icon"><i class="fas fa-adjust"></i></span>
+            </button>
+          </div>
         </div>
         <!--
         <div id="left-navbar" class="navbar-menu">
@@ -74,6 +82,7 @@
     </body>
     <!-- You've gotta have utils.js -->
   <script src="js/utils.js"></script>
+  <script src="js/theme.js"></script>
   
   [[block page_scripts]]<!-- individual pages can add scripts here -->[[end]]
 </html>


### PR DESCRIPTION
## Summary
- implement a simple dark theme using CSS variables
- add theme toggle button to the navbar
- load theme script and stylesheet
- document new interface feature in README

## Testing
- `python -m py_compile *.py */*.py`

------
https://chatgpt.com/codex/tasks/task_e_687ea4e61f648330b47c9a78d41f9e21